### PR TITLE
Update compilationunit.lua

### DIFF
--- a/compilationunit.lua
+++ b/compilationunit.lua
@@ -30,7 +30,7 @@ premake.extensions.compilationunit = {
 function premake.extensions.compilationunit.customBakeFiles(base, prj)
 
 	-- if compilation units are disabled for this project, do nothing
-	if prj.compilationunitenabled ~= true then
+	if prj.compilationunitenabled ~= true or prj.external == true then
 		return base(prj)
 	end
 


### PR DESCRIPTION
BakeFiles seems to be called for each project even if it's declared as external.
Adding this test fix the issue I was encountering.
