### PR TITLE
Allow excluding file from compilation unit

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -38,6 +38,16 @@ premake.api.register {
 
 
 --
+-- List of files that will be excluded when creating compilationunit
+--
+premake.api.register {
+	name = "compilationunitexclude",
+	scope = "config",
+	kind = "string-list"
+}
+
+
+--
 -- Always load
 --
 return function () return true end

--- a/compilationunit.lua
+++ b/compilationunit.lua
@@ -189,6 +189,10 @@ function premake.extensions.compilationunit.isIncludedInCompilationUnit(cfg, fil
 		return false
 	end
 
+	if cu.isExcludedFromCU(cfg, filename) then
+		return false
+	end
+
 	-- it's ok !
 	return true
 end
@@ -226,6 +230,27 @@ function premake.extensions.compilationunit.getCompilationUnitDir(cfg)
 	return path.getabsolute(dir)
 end
 
+--
+-- Check whether the file should be excluded from the compilation unit
+--
+-- @param cfg
+--		The input configuration
+-- @param absfilename
+--		The filename of the file to check
+-- @return
+--		True if this should be excluded, False otherwise
+--
+function premake.extensions.compilationunit.isExcludedFromCU(cfg, fileName)
+	if cfg.compilationunitexclude then
+		for index, value in ipairs(cfg.compilationunitexclude) do
+			if path.getname(fileName) == value then
+				return true
+			end
+		end
+	end
+
+	return false
+end
 
 --
 -- Get the name of a compilation unit


### PR DESCRIPTION
Hello, 

So I notice there's no easy way to exclude specific file from the compilation unit. Can you check my code which adds that capability. It will only check the filename, so all files with the same name will also be excluded.

To use, add following line in the project config (i.e. after line compilationunitenabled):
compilationunitexclude { "filename1.cpp", "filename2.cpp" }