### PR TITLE
Allow to override the compilation unit extensions.

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -30,12 +30,33 @@ premake.api.register {
 -- unit files will be stored. If not specified, the project's obj dir will be used.
 --
 premake.api.register {
-       name = "compilationunitdir",
-       scope = "project",
-       kind = "path",
-       tokens = true
+	name = "compilationunitdir",
+	scope = "project",
+	kind = "path",
+	tokens = true
 }
 
+-- Compilation unit extensions.
+--
+-- By default, either .c or .cpp extension are used for generated compilation units.
+-- But you can override this extension per-language to let it handle objective-C or
+-- any other.
+--
+-- Here's an example allowing to mix C or C++ files with objective-C:
+-- 
+-- filter {}
+-- 	compilationunitextensions {
+--		"C" = ".m",	-- compilation unit extension for C files is .m
+--				-- (i.e. objective-C)
+--		"C++" = ".mm"	-- compilation unit extension for C++ files is .mm
+--				-- (i.e. objective-C++)
+--	}
+--
+premake.api.register {
+	name = "compilationunitextensions",
+	scope = "config",
+	kind = "table"
+}
 
 --
 -- Always load

--- a/compilationunit.lua
+++ b/compilationunit.lua
@@ -247,7 +247,19 @@ end
 --		The name of the file.
 --
 function premake.extensions.compilationunit.getCompilationUnitName(cfg, index, shortName)
-	return premake.extensions.compilationunit.compilationunitname .. index .. iif(cfg.language == "C", ".c", ".cpp")
+
+	local language = cfg.language
+	local extension = nil
+	
+	if cfg.compilationunitextensions ~= nil then
+		extension = cfg.compilationunitextensions[language]
+	end
+	
+	if extension == nil then
+		extension = iif(language == "C", ".c", ".cpp")
+	end
+	
+	return premake.extensions.compilationunit.compilationunitname .. index .. extension
 end
 
 
@@ -296,7 +308,7 @@ if _OPTIONS["compilationunit"] ~= nil then
 
 	-- setup the overrides
 	premake.override(premake.oven, "bakeFiles", cu.customBakeFiles)
-	premake.override(premake.fileconfig, "addconfig",  cu.customAddFileConfig)
+	premake.override(premake.fileconfig, "addconfig", cu.customAddFileConfig)
 	premake.override(premake.oven, "bakeConfigs", cu.customBakeConfigs)
 
 end


### PR DESCRIPTION
Please merge this PR which allows to override the file extension of the compilation units. It includes the fixes requested in PR #7.

Regards,

Julien