### PR TITLE
Remove the files of the units from cfg.files.

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -38,6 +38,18 @@ premake.api.register {
 
 
 --
+-- Tell if the original source files must be removed from the project (true), thus
+-- keeping only the the generated compilation units, or if all files are kept (false).
+--
+-- Default is to keep the original source files.
+--
+premake.api.register {
+	name = "compilationunitsonly",
+	scope = "config",
+	kind = "boolean"
+}
+
+--
 -- Always load
 --
 return function () return true end

--- a/compilationunit.lua
+++ b/compilationunit.lua
@@ -49,12 +49,24 @@ function premake.extensions.compilationunit.customBakeFiles(base, prj)
 			end
 		end
 
+		-- the indices of the files that must be included in the compilation units
+		local sourceindexforcu = {}
+
 		-- store the list of files for a later building of the actual compilation unit files
-		table.foreachi(cfg.files, function(filename)
+		for i = #cfg.files, 1, -1 do
+			local filename = cfg.files[i]
 			if cu.isIncludedInCompilationUnit(cfg, filename) == true then
 				table.insert(cu.compilationunits[cfg], filename)
+				table.insert(sourceindexforcu, i)
 			end
-		end)
+		end
+
+		-- remove the original source files from the project
+		if cfg.compilationunitsonly then
+			table.foreachi(sourceindexforcu, function(i)
+				table.remove(cfg.files, i)
+			end)
+		end
 
 		-- store the compilation unit folder in the config
 		if cfg._compilationUnitDir == nil then


### PR DESCRIPTION
Please merge this PR which adds an option to remove the original source files from the project when creating compilation units. It includes the fixes requested in PR #7.

Regards,

Julien